### PR TITLE
ensures single file path is passed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-ts-path-alias",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Gulp Task to transform Typescript path imports into relative paths using the tsconfig",
   "main": "index.js",
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -13,11 +13,11 @@ function gulpPathAlias(baseUrl, paths) {
   return through.obj(function (file, enc, cb) {
     if (file.isBuffer()) {
       var code = file.contents.toString("utf-8");
-      code = replacePath(code, file.history.toString(), baseUrl, paths);
+      code = replacePath(code, file.path, baseUrl, paths);
       file.contents = Buffer.from(code, 'utf-8');
     } else if (file.isStream()) {
       var code = fs.readFileSync(file.path, "utf8");
-      code = replacePath(code, file.history.toString(), baseUrl, paths);
+      code = replacePath(code, file.path, baseUrl, paths);
       file.contents = Buffer.from(code, 'utf-8');
     }
 


### PR DESCRIPTION
before this commit,
history.toString() is used to get the path. this implementation is only
valid if history.length is 1, otherwise a comma separated list of files
is passed to replacePath. this commit uses the current path.